### PR TITLE
AXL: protect AXL's transfer file lists in multi-threading transfers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,7 @@ OPTION(AXL_LINK_STATIC "Default to static linking? (Needed for Cray)" OFF)
 SET(AXL_ASYNC_API "NONE" CACHE STRING "Vendor-specific asynchronous file transfer (CRAY_DW INTEL_CPPR IBM_BBAPI NONE)")
 SET_PROPERTY(CACHE AXL_ASYNC_API PROPERTY STRINGS NONE CRAY_DW INTEL_CPPR IBM_BBAPI)
 
-
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror")
+SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 
 # Find Packages & Files
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,45 @@
+# SCR/VELOC Community Code of Conduct
+
+This software is developed as part of the [SCR](https://github.com/LLNL/SCR) and [VELOC](https://veloc.readthedocs.io/) software projects.
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the either the SCR or VELOC project or its community. Examples of representing the project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of the project may be further defined and clarified by SCR and VELOC maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the SCR PI at `kathryn@llnl.gov`. The team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/) ([version 1.4](http://contributor-covenant.org/version/1/4)).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# SCR/VELOC Contributing Guidelines
+
+This software is developed as part of the [SCR](https://github.com/LLNL/SCR) and [VELOC](https://veloc.readthedocs.io/) software projects.
+
+This is an open source project. We welcome contributions via pull requests as well as questions, feature requests, or bug reports via issues. Contact our team through GitHub issues, via the [SCR mailing lists](https://computing.llnl.gov/projects/scalable-checkpoint-restart-for-mpi/contact), or the [VELOC mailing list](veloc-users@lists.mcs.anl.gov). Please also refer to our [code of conduct](CODE_OF_CONDUCT.md).
+
+If you aren't an SCR developer at LLNL or VELOC developer as part of ECP, you won't have permission to push new branches to the repository. First, you should create a fork. This will create your copy of this repository and ensure you can push your changes up to GitHub and create PRs. This project uses ECP internal resources via gitlab runners to test code changes. Please include details on how we can test your contribution.
+
+* Create your branches off the `master` branch.
+* Clearly name your branches, commits, and PRs as this will help us manage queued work in a timely manner.
+* Articulate your commit messages in the imperative (e.g., `Adds new privacy policy link to README`).
+* Commit your work in logically organized commits, and group commits together logically in a PR.
+* Title each PR clearly and give it an unambiguous description.
+* Review existing issues before opening a new one. Your issue might already be under development or discussed by others. Feel free to add to any outstanding issue/bug.
+* Be explicit when opening issues and reporting bugs. What behavior are you expecting? What is your justification or use case for the new feature/enhancement? How can the bug be recreated? What are any environment variables to consider?

--- a/doc/README.md
+++ b/doc/README.md
@@ -62,6 +62,11 @@ DEBUG           |    Boolean |       0 |  No | Set to 1 to have AXL print debug 
 MKDIR           |    Boolean |       1 | Yes | Specifies whether the destination file system supports the creation of directories (1) or not (0).
 COPY\_METADATA  |    Boolean |       0 | Yes | Whether file metadata like timestamp and permission bits should also be copied.
 
+Thread safety: setting the DEBUG or any per-transfer configuration value after
+the transfer has been dispatched entails a race contion between the main thread
+and the worker threads. Changing configuration options after a transfer has
+been dispatched is not supported.
+
 # Transferring files
 Regardless of the transfer type, the basic control flow of a transfer is always:
 1. AXL\_Create - allocate a new transfer object, providing its type and a name

--- a/src/axl.c
+++ b/src/axl.c
@@ -239,9 +239,8 @@ API Functions
 ========================================
 */
 
-/* Read configuration from non-AXL-specific file
-  Also, start up vendor specific services */
-int __AXL_Init (const char* state_file)
+/* Initialize library and start up vendor specific services */
+int AXL_Init (void)
 {
     int rc = AXL_SUCCESS;
 
@@ -268,11 +267,6 @@ int __AXL_Init (const char* state_file)
     val = getenv("AXL_MKDIR");
     if (val != NULL) {
         axl_make_directories = atoi(val);
-    }
-
-    if (state_file != NULL) {
-        printf("WARNING: Passing a state_file to AXL_Init() is deprecated." \
-               "Pass it to AXL_Create(id, type, state_file) instead.\n");
     }
 
 #ifdef HAVE_BBAPI
@@ -544,7 +538,7 @@ kvtree* AXL_Config(const kvtree* config)
  * Type specifies a particular method to use
  * Name is a user/application provided string
  * Returns an ID to the transfer handle */
-int __AXL_Create(axl_xfer_t xtype, const char* name, const char* state_file)
+int AXL_Create(axl_xfer_t xtype, const char* name, const char* state_file)
 {
     /* Generate next unique ID */
     int id = axl_alloc_id(state_file);

--- a/src/axl.h
+++ b/src/axl.h
@@ -52,19 +52,10 @@ typedef enum {
     AXL_XFER_STATE_FILE,    /* Use the xfer type specified in the state_file. */
 } axl_xfer_t;
 
-#define ARG0(dummy, a0, ...) a0
-#define GET_ARG0(...) ARG0(dummy, ## __VA_ARGS__, 0)
-
 /*
  * int AXL_Init(void) - Initialize the library.
- *
- * NOTE: AXL_Init() used to take in a state_file argument, but this has
- * since been removed. We do some macro mangling to make sure both state_file
- * version and the no-arg version both work, but the state_file version is
- * deprecated and should not be used.
  */
-#define AXL_Init(...) __AXL_Init(GET_ARG0(__VA_ARGS__))
-int __AXL_Init (const char* state_file);
+int AXL_Init (void);
 
 /** Shutdown any vendor services */
 int AXL_Finalize (void);
@@ -78,16 +69,8 @@ int AXL_Finalize (void);
  *              resume transfers after a crash.
  *
  * Returns an AXL ID, or negative number on error.
- *
- * NOTE: AXL_Create() used to only take in type and name.  The state_file arg
- * was added later.  We do some macro mangling to make sure both 2-arg and
- * 3-arg versions of AXL_Create() work, but the 2-arg version is deprecated
- * and should not be used.  If you're loading from an existing state_file, then
- * type must be the same as the type in state_file.
  */
-#define AXL_Create(type, name, ...) \
-        __AXL_Create(type, name, GET_ARG0(__VA_ARGS__))
-int __AXL_Create (axl_xfer_t xtype, const char* name, const char* state_file);
+int AXL_Create (axl_xfer_t xtype, const char* name, const char* state_file);
 
 /**
  * Get/set AXL configuration values.

--- a/src/axl.h
+++ b/src/axl.h
@@ -72,6 +72,9 @@ int AXL_Finalize (void);
  */
 int AXL_Create (axl_xfer_t xtype, const char* name, const char* state_file);
 
+/* needs to be above doxygen comment to get association right */
+typedef struct kvtree_struct kvtree;
+
 /**
  * Get/set AXL configuration values.
  *
@@ -80,11 +83,15 @@ int AXL_Create (axl_xfer_t xtype, const char* name, const char* state_file);
  *              then return a kvtree with all the configuration values (globals
  *              and all per-ID trees).
  *
+ * Thread safety: setting the DEBUG or any per-transfer configuration value
+ * after the transfer has been dispatched entails a race contion between the
+ * main thread and the worker threads. Changing configuration options after a
+ * transfer has been dispatched is not supported.
+ *
  * Return value: If config != NULL, then return config on success.  If
  *                      config=NULL (you're querying the config) then return
  *                      a new kvtree on success.  Return NULL on any failures.
  */
-typedef struct kvtree_struct kvtree;
 kvtree* AXL_Config(
   const kvtree* config        /** [IN] - kvtree of options */
 );

--- a/src/axl_internal.h
+++ b/src/axl_internal.h
@@ -14,13 +14,19 @@
 #define AXL_SUCCESS (0)
 #define AXL_FAILURE (-1)
 
+/* unless otherwise indicated all global variables defined in this file must
+ * only be accessed by the main thread */
+
 /*
  * A list of pointers to kvtrees, indexed by AXL ID.
  */
 extern kvtree** axl_kvtrees;
 
 /* current debug level for AXL library,
- * set in AXL_Init used in axl_dbg */
+ * set in AXL_Init and AXL_Config used in axl_dbg.
+ * There can be a race condition between the main thread setting this in
+ * AXL_Config and worker threads using it. Users are advised to be careful
+ * using debug options. */
 extern int axl_debug;
 
 /* flag to track whether file metadata should also be copied,

--- a/src/axl_internal.h
+++ b/src/axl_internal.h
@@ -116,7 +116,6 @@ int axl_file_copy(
     const char* src_file,
     const char* dst_file,
     unsigned long buf_size,
-    int copy_metadata,
     int resume
 );
 
@@ -171,5 +170,8 @@ int axl_meta_encode(const char* file, kvtree* meta);
 
 /* copy metadata settings recorded in provided kvtree to specified file */
 int axl_meta_apply(const char* file, const kvtree* meta);
+
+/* Check if a file is the size we expect it to be */
+int axl_check_file_size(const char* file, const kvtree* meta);
 
 #endif /* AXL_INTERNAL_H */

--- a/src/axl_pthread.c
+++ b/src/axl_pthread.c
@@ -217,13 +217,8 @@ static void* axl_pthread_func(void* arg)
                                             AXL_KEY_CONFIG_FILE_BUF_SIZE, &file_buf_size);
         assert(success == KVTREE_SUCCESS);
 
-        int copy_metadata;
-        success = kvtree_util_get_int(file_list, AXL_KEY_CONFIG_COPY_METADATA,
-                                      &copy_metadata);
-        assert(success == KVTREE_SUCCESS);
-
         /* Copy the file from soruce to destination */
-        int rc = axl_file_copy(src, dst, file_buf_size, copy_metadata, pdata->resume);
+        int rc = axl_file_copy(src, dst, file_buf_size, pdata->resume);
         AXL_DBG(2, "%s: Read and copied %s to %s, rc %d",
             __func__, src, dst, rc);
 

--- a/src/axl_sync.c
+++ b/src/axl_sync.c
@@ -44,16 +44,10 @@ int __axl_sync_start (int id, int resume)
                                             AXL_KEY_CONFIG_FILE_BUF_SIZE, &file_buf_size);
         assert(success == KVTREE_SUCCESS);
 
-        int copy_metadata;
-        success = kvtree_util_get_int(file_list, AXL_KEY_CONFIG_COPY_METADATA,
-                                      &copy_metadata);
-        assert(success == KVTREE_SUCCESS);
-
         /* Copy the file */
         char* destination;
         kvtree_util_get_str(elem_hash, AXL_KEY_FILE_DEST, &destination);
-        int tmp_rc = axl_file_copy(source, destination, file_buf_size,
-                                   copy_metadata, resume);
+        int tmp_rc = axl_file_copy(source, destination, file_buf_size, resume);
         if (tmp_rc == AXL_SUCCESS) {
             kvtree_util_set_int(elem_hash, AXL_KEY_FILE_STATUS, AXL_STATUS_DEST);
         } else {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,9 +21,11 @@ TARGET_LINK_LIBRARIES(test_config axl)
 ################
 
 CONFIGURE_FILE(test_axl.sh ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
+CONFIGURE_FILE(test_axl_metadata.sh ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
 
 ADD_TEST(sync_test test_axl.sh sync)
 ADD_TEST(pthreads_test test_axl.sh pthread)
+ADD_TEST(metadata_test test_axl_metadata.sh)
 IF(BBAPI_FOUND)
     ADD_TEST(bbapi_test test_axl.sh bbapi)
 

--- a/test/test_axl_metadata.sh
+++ b/test/test_axl_metadata.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# AXL metadata copy test.
+#
+# Make two files, set some metadata on them (size, times, permission), copy
+# the file, and verify the metadata is correct.
+
+src=$(mktemp -d)
+dest=$(mktemp -d)
+
+trap ctrl_c INT
+
+function cleanup
+{
+	rm -fr "$src" "$dest"
+}
+
+function ctrl_c() {
+	cleanup
+}
+
+# Create two files and set some metadata
+dd if=/dev/zero of=$src/file1 bs=1 count=1
+dd if=/dev/zero of=$src/file2 bs=1 count=5
+
+chmod 444 $src/file1
+chmod 777 $src/file2
+touch -d "1 hour ago" $src/file1
+touch -d "1 day ago" $src/file2
+
+# Do a simple transfer and verify the result
+./axl_cp -a $src/* $dest
+src_ls="$(ls -l $src)"
+dest_ls="$(ls -l $dest)"
+
+if [ "$src_ls" != "$dest_ls" ] ; then
+	echo "Error: source and dest metadata doesn't match:"
+	echo "$src_ls"
+	echo "-----------------------------------"
+	echo "$dest_ls"
+	cleanup
+	exit 1
+fi
+
+rm -f $dest/*
+
+# Now do another transfer without copying metadata. The permissions
+# should be different between the source and destination.
+./axl_cp $src/* $dest
+src_ls="$(ls -l $src)"
+dest_ls="$(ls -l $dest)"
+if [ "$src_ls" == "$dest_ls" ] ; then
+	echo "Error: source and dest metadata matches, but shouldn't:"
+	echo "$src_ls"
+	echo "-----------------------------------"
+	echo "$dest_ls"
+	cleanup
+	exit 1
+fi
+cleanup

--- a/test/test_config.c
+++ b/test/test_config.c
@@ -369,7 +369,7 @@ main(void) {
     old_axl_copy_metadata = axl_copy_metadata;
 
     /* must pick up "old" defaults */
-    int id1 = AXL_Create(AXL_XFER_DEFAULT, __FILE__);
+    int id1 = AXL_Create(AXL_XFER_DEFAULT, __FILE__, NULL);
     if (id1 < 0) {
         printf("AXL_Create() failed (error %d)\n", id1);
         exit(EXIT_FAILURE);
@@ -379,7 +379,7 @@ main(void) {
     get_global_options();
 
     /* must pick up "new" defaults */
-    int id2 = AXL_Create(AXL_XFER_DEFAULT, __FILE__);
+    int id2 = AXL_Create(AXL_XFER_DEFAULT, __FILE__, NULL);
     if (id2 < 0) {
         printf("AXL_Create() failed (error %d)\n", id2);
         exit(EXIT_FAILURE);


### PR DESCRIPTION
Branch https://github.com/rhaas80/AXL/tree/rhaas/locks contains an implementation protecting against the race condition. Changes are: https://github.com/rhaas80/AXL/compare/rhaas/keyvalue...rhaas80:rhaas/locks

Implementation notes:

* this protects only `axl_kvtrees` but not the other global variables (that hold configuration options), since the latter are only accessed in the main thread so those do not share a race condition
* calling `AXL_Config` on a transfer that has already been dispatch is a race condition (since there is no lock on the individual `file_list` kvtrees) and not supported
* calling `AXL_Config` for the DEBUG settings is race condition (since `axl_debug` is not protected but is accessed from within the worker threads) while there are already dispatched transfers and will not be fixed